### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/org/nmrfx/processor/star/Saveframe.java
+++ b/src/main/java/org/nmrfx/processor/star/Saveframe.java
@@ -207,6 +207,19 @@ public class Saveframe {
         return result;
     }
 
+    public String getOptionalLabelValue(String tagCategory, String tag) throws ParseException {
+        Category category = getCategory(tagCategory);
+        String value = (String) category.get(tag);
+        String result = "";
+        if (value != null) {
+            result = value;
+        }
+        if (value.startsWith("$")) {
+            result = value.substring(1);
+        }
+        return result;
+    }
+
     public int getIntegerValue(String tagCategory, String tag) throws ParseException {
         String value = getValue(tagCategory, tag);
         try {

--- a/src/main/scripts/nmrfxp
+++ b/src/main/scripts/nmrfxp
@@ -25,6 +25,8 @@ else
     HEAP_MEM="2048"
 fi
 
+JAVA=java
+
 # get the directory path of this script
 # resolve script symlink, if any
 pgm="$0"


### PR DESCRIPTION
1) Leading "$" was not being stripped from SampleConditionLabel when reading from STAR file. It was being set using SaveFrame.getOptionalValue method which has no logic to strip the leading "$". I have added a getOptionalLabelValue method rather than modifying getOptionalValue because I don't know whether it's safe to assume every leading "$" should be stripped.

2) $JAVA not always set in nmrfxp script

