### PR TITLE
Allow multiple projects to be loaded simultaneously

### DIFF
--- a/src/main/java/org/nmrfx/processor/datasets/Dataset.java
+++ b/src/main/java/org/nmrfx/processor/datasets/Dataset.java
@@ -47,6 +47,7 @@ import org.renjin.sexp.DoubleVector;
 import org.renjin.sexp.DoubleArrayVector;
 import org.renjin.sexp.IntArrayVector;
 import org.renjin.sexp.SEXP;
+import org.nmrfx.project.Project;
 
 /**
  * Instances of this class represent NMR datasets. The class is typically used
@@ -65,7 +66,9 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
 //        } catch (IOException ioE) {
 //        }
 //    }
-    private static HashMap<String, Dataset> theFiles = new HashMap<>();
+    private static HashMap<String, Dataset> theFiles () {
+        return Project.getActive().datasetList;
+    }
     public final static int NV_HEADER_SIZE = 2048;
     public final static int UCSF_HEADER_SIZE = 180;
     public final static int LABEL_MAX_BYTES = 16;
@@ -524,7 +527,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
      */
     public static boolean checkExistingName(final String name) {
         boolean exists = false;
-        Dataset existingFile = (Dataset) theFiles.get(name);
+        Dataset existingFile = (Dataset) theFiles().get(name);
         if (existingFile != null) {
             exists = true;
         }
@@ -543,7 +546,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
         String testPath;
         testPath = file.getCanonicalPath();
         ArrayList<String> names = new ArrayList<>();
-        theFiles.values().stream().filter((dataset) -> (dataset.canonicalName.equals(testPath))).forEach((dataset) -> {
+        theFiles().values().stream().filter((dataset) -> (dataset.canonicalName.equals(testPath))).forEach((dataset) -> {
             names.add(dataset.getName());
         });
         return names;
@@ -569,7 +572,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
         do {
             index++;
             newName = rootName + "_" + index + ext;
-        } while (theFiles.get(newName) != null);
+        } while (theFiles().get(newName) != null);
         return newName;
     }
 
@@ -765,7 +768,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
     }
 
     private void addFile(String fileName) {
-        theFiles.put(fileName, this);
+        theFiles().put(fileName, this);
         for (DatasetListener observer : observers) {
             try {
                 observer.datasetAdded(this);
@@ -776,7 +779,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
     }
 
     private void removeFile(String fileName) {
-        theFiles.remove(fileName);
+        theFiles().remove(fileName);
         for (DatasetListener observer : observers) {
             try {
                 observer.datasetRemoved(this);
@@ -792,10 +795,10 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
      * @param newName the name to be used.
      */
     synchronized public void rename(String newName) {
-        if (null != theFiles.remove(fileName)) {
+        if (null != theFiles().remove(fileName)) {
             fileName = newName;
             title = fileName;
-            theFiles.put(newName, this);
+            theFiles().put(newName, this);
             for (DatasetListener observer : observers) {
                 try {
                     observer.datasetRenamed(this);
@@ -3508,7 +3511,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
         if (fileName == null) {
             return null;
         } else {
-            return ((Dataset) theFiles.get(fileName));
+            return ((Dataset) theFiles().get(fileName));
         }
     }
 
@@ -3518,7 +3521,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
      * @return List of names.
      */
     synchronized public static List<String> names() {
-        List<String> names = theFiles.keySet().stream().sorted().collect(Collectors.toList());
+        List<String> names = theFiles().keySet().stream().sorted().collect(Collectors.toList());
         return names;
     }
 
@@ -3528,7 +3531,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
      * @return List of datasets.
      */
     synchronized public static List<Dataset> datasets() {
-        List<Dataset> datasets = theFiles.values().stream().collect(Collectors.toList());
+        List<Dataset> datasets = theFiles().values().stream().collect(Collectors.toList());
         return datasets;
     }
 
@@ -3575,7 +3578,7 @@ public class Dataset extends DoubleVector implements Comparable<Dataset> {
     public static TreeSet getPropertyNames() {
         TreeSet nameSet = new TreeSet();
 
-        for (Dataset dataset : theFiles.values()) {
+        for (Dataset dataset : theFiles().values()) {
             Iterator iter = dataset.properties.keySet().iterator();
             while (iter.hasNext()) {
                 String propName = (String) iter.next();

--- a/src/main/java/org/nmrfx/processor/datasets/peaks/PeakDim.java
+++ b/src/main/java/org/nmrfx/processor/datasets/peaks/PeakDim.java
@@ -20,26 +20,16 @@ package org.nmrfx.processor.datasets.peaks;
 import org.nmrfx.processor.star.STAR3;
 import org.nmrfx.processor.utilities.ConvUtil;
 import org.nmrfx.processor.utilities.Format;
+import org.nmrfx.project.Project;
 import java.util.ArrayList;
 import java.util.List;
 
 public class PeakDim {
 
-    public static ResonanceFactory resFactory;
-
-    static {
-        try {
-            Class c = Class.forName("org.nmrfx.processor.datasets.peaks.AtomResonanceFactory");
-            try {
-                resFactory = (ResonanceFactory) c.newInstance();
-            } catch (InstantiationException | IllegalAccessException ex) {
-                resFactory = new ResonanceFactory();
-            }
-        } catch (ClassNotFoundException ex) {
-            resFactory = new ResonanceFactory();
-        }
-        resFactory.init();
+    public static ResonanceFactory resFactory() {
+        return Project.getActive().resFactory;
     }
+
     public static List<PeakDim> EMPTY_LIST = new ArrayList<>();
 
     private int spectralDim = 0;
@@ -75,7 +65,7 @@ public class PeakDim {
     }
 
     public static void setResonanceFactory(ResonanceFactory newFactory) {
-        resFactory = newFactory;
+        Project.getActive().resFactory = newFactory;
     }
 
     public PeakDim copy(Peak peak) {
@@ -147,7 +137,7 @@ public class PeakDim {
     }
 
     public void initResonance() {
-        resonance = resFactory.build();
+        resonance = resFactory().build();
         resonance.add(this);
     }
 
@@ -205,7 +195,7 @@ public class PeakDim {
 
     public void setResonance(long resID) {
         remove();
-        resonance = resFactory.get(resID);
+        resonance = resFactory().get(resID);
     }
 
     public void setResonance(Resonance newResonance) {

--- a/src/main/java/org/nmrfx/processor/datasets/peaks/PeakList.java
+++ b/src/main/java/org/nmrfx/processor/datasets/peaks/PeakList.java
@@ -53,6 +53,7 @@ import org.nmrfx.processor.datasets.RegionData;
 import static org.nmrfx.processor.datasets.peaks.Peak.getMeasureFunction;
 import smile.clustering.HierarchicalClustering;
 import smile.clustering.linkage.CompleteLinkage;
+import org.nmrfx.project.Project;
 
 /**
  *
@@ -93,7 +94,9 @@ public class PeakList {
     /**
      *
      */
-    public static ObservableMap<String, PeakList> peakListTable = FXCollections.observableMap(new LinkedHashMap<>());
+    public static ObservableMap<String, PeakList> peakListTable () {
+        return Project.getActive().peakListTable;
+    }
 
     /**
      *
@@ -209,8 +212,8 @@ public class PeakList {
         peaks = new ArrayList<>();
         indexMap.clear();
 
-        peakListTable.put(listName, this);
-        listNum = peakListTable.size();
+        peakListTable().put(listName, this);
+        listNum = peakListTable().size();
     }
 
     @Override
@@ -305,7 +308,7 @@ public class PeakList {
      * @return
      */
     public static Iterator iterator() {
-        return peakListTable.values().iterator();
+        return peakListTable().values().iterator();
     }
 
     /**
@@ -330,9 +333,9 @@ public class PeakList {
      * @param newName
      */
     public void setName(String newName) {
-        peakListTable.remove(listName);
+        peakListTable().remove(listName);
         listName = newName;
-        peakListTable.put(newName, this);
+        peakListTable().put(newName, this);
     }
 
     /**
@@ -535,7 +538,7 @@ public class PeakList {
      */
     public static boolean isAnyChanged() {
         boolean anyChanged = false;
-        for (PeakList checkList : peakListTable.values()) {
+        for (PeakList checkList : peakListTable().values()) {
             if (checkList.isChanged()) {
                 anyChanged = true;
                 break;
@@ -549,7 +552,7 @@ public class PeakList {
      *
      */
     public static void clearAllChanged() {
-        for (Object checkList : peakListTable.values()) {
+        for (Object checkList : peakListTable().values()) {
             ((PeakList) checkList).clearChanged();
         }
     }
@@ -760,7 +763,7 @@ public class PeakList {
      * @return
      */
     public static List<PeakList> getLists() {
-        List<PeakList> peakLists = PeakList.peakListTable.values().stream().collect(Collectors.toList());
+        List<PeakList> peakLists = peakListTable().values().stream().collect(Collectors.toList());
         return peakLists;
     }
 
@@ -770,7 +773,7 @@ public class PeakList {
      * @return
      */
     public static PeakList get(String listName) {
-        return ((PeakList) peakListTable.get(listName));
+        return ((PeakList) peakListTable().get(listName));
     }
 
     /**
@@ -795,7 +798,7 @@ public class PeakList {
      * @param listName
      */
     public static void remove(String listName) {
-        PeakList peakList = (PeakList) peakListTable.get(listName);
+        PeakList peakList = (PeakList) peakListTable().get(listName);
         if (peakList != null) {
             peakList.remove();
         }
@@ -815,7 +818,7 @@ public class PeakList {
         peaks = null;
         schedExecutor.shutdown();
         schedExecutor = null;
-        peakListTable.remove(listName);
+        peakListTable().remove(listName);
     }
 
     void swap(double[] limits) {
@@ -1289,7 +1292,7 @@ public class PeakList {
 
         int lastDot = peakSpecifier.lastIndexOf('.');
 
-        PeakList peakList = (PeakList) peakListTable.get(peakSpecifier.substring(
+        PeakList peakList = (PeakList) peakListTable().get(peakSpecifier.substring(
                 0, dot));
 
         if (peakList == null) {
@@ -1329,7 +1332,7 @@ public class PeakList {
 
         int lastDot = peakSpecifier.lastIndexOf('.');
 
-        PeakList peakList = (PeakList) peakListTable.get(peakSpecifier.substring(
+        PeakList peakList = (PeakList) peakListTable().get(peakSpecifier.substring(
                 0, dot));
 
         if (peakList == null) {
@@ -1369,7 +1372,7 @@ public class PeakList {
 
         int lastDot = peakSpecifier.lastIndexOf('.');
 
-        PeakList peakList = (PeakList) peakListTable.get(peakSpecifier.substring(
+        PeakList peakList = (PeakList) peakListTable().get(peakSpecifier.substring(
                 0, dot));
 
         if (peakList == null) {
@@ -1498,7 +1501,7 @@ public class PeakList {
 
         int lastDot = peakSpecifier.lastIndexOf('.');
 
-        PeakList peakList = (PeakList) peakListTable.get(peakSpecifier.substring(
+        PeakList peakList = (PeakList) peakListTable().get(peakSpecifier.substring(
                 0, dot));
 
         if (peakList == null) {
@@ -3796,7 +3799,7 @@ public class PeakList {
      * @return
      */
     public static PeakList getPeakListForDataset(String datasetName) {
-        for (PeakList peakList : peakListTable.values()) {
+        for (PeakList peakList : peakListTable().values()) {
             if (peakList.fileName.equals(datasetName)) {
                 return peakList;
             }

--- a/src/main/java/org/nmrfx/processor/datasets/peaks/PeakPath.java
+++ b/src/main/java/org/nmrfx/processor/datasets/peaks/PeakPath.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import org.apache.commons.math3.optimization.PointVectorValuePair;
 import org.apache.commons.math3.optimization.general.LevenbergMarquardtOptimizer;
 import org.nmrfx.processor.datasets.Dataset;
+import org.nmrfx.project.Project;
 import smile.interpolation.KrigingInterpolation;
 import smile.interpolation.variogram.PowerVariogram;
 import smile.interpolation.variogram.Variogram;
@@ -44,7 +45,9 @@ public class PeakPath implements PeakListener {
     static String[] PRESURE_NAMES = {"Ha", "Hb", "Hc", "Xa", "Xb", "Xc"};
     static String[] TITRATION_NAMES = {"K", "C"};
 
-    static Map<String, PeakPath> peakPaths = new HashMap<>();
+    static Map<String, PeakPath> peakPaths () {
+        return Project.getActive().peakPaths;
+    }
 
     public enum PATHMODE {
         TITRATION,
@@ -482,20 +485,20 @@ public class PeakPath implements PeakListener {
     }
 
     public void store() {
-        peakPaths.put(name, this);
+        peakPaths().put(name, this);
     }
 
     public void store(String name) {
         this.name = name;
-        peakPaths.put(name, this);
+        peakPaths().put(name, this);
     }
 
     public static Collection<PeakPath> get() {
-        return peakPaths.values();
+        return peakPaths().values();
     }
 
     public static PeakPath get(String name) {
-        return peakPaths.get(name);
+        return peakPaths().get(name);
     }
 
     public String getName() {


### PR DESCRIPTION
With our workflow, being able to easily access other projects (e.g. fragments of a larger molecule) would be highly enabling. The forthcoming pull requests are a suggestion for how this might be achieved. I appreciate you will probably be wary of this and so for this initial pull request the changes are minimal - if you agree with this approach then I can suggest some additional changes which facilitate this type of workflow.

The reason that it is not currently possible to load multiple projects is that there are a number of static variables which store project information which are set when a project is loaded and read from when a project is saved. In nmrfxprocessor these are:

Dataset.theFiles
PeakList.peakListTable
PeakDim.resFactory
PeakPath.peakPaths

I have changed these to be instances of a Project object, so they can be independently managed between projects.

Dataset.theFiles -> theProject.datasetList
PeakList.peakListTable -> theProject.peakListTable
PeakDim.resFactory -> theProject.resFactory
PeakPath.peakPaths -> theProject.peakPaths

The original static variables have been converted to static methods which return the relevant variable from the active project. For example:

    private static HashMap<String, Dataset> theFiles = new HashMap<>();

Becomes:

    private static HashMap<String, Dataset> theFiles () {
        return Project.getActive().datasetList;
    }

And all references to Dataset.theFiles become Dataset.theFiles() .

The only other changes are in Project.java.

First, it is necessary that an active project is always return from Project.getActive(). If there is no activeProject, a new project is now created with the following precedence:

GUIStructureProject, StructureProject, GUIProject, Project

Finally, project.loadProject() and project.saveProject() store the currently active project before making the owning object active, and then restore after the save or load is complete.

In my testing, this allows me to load a project, and then (in Jython) do something like:

project1=Project("testproject1")
project1.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject1"))
project2=Project("testproject2")
project1.setActive()
project2.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject2"))

#access and modify peaklists, assignments etc. within each project

currentProject.saveProject()
subProject.saveProject()