### PR TITLE
PeakList.get() should return null for invalid int

### DIFF
--- a/src/main/java/org/nmrfx/processor/datasets/peaks/PeakList.java
+++ b/src/main/java/org/nmrfx/processor/datasets/peaks/PeakList.java
@@ -828,10 +828,10 @@ public class PeakList {
         while (iter.hasNext()) {
             peakList = (PeakList) iter.next();
             if (listID == peakList.listNum) {
-                break;
+                return peakList;
             }
         }
-        return peakList;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Apologies Bruce, I didn't include one of my changes in the previous pull request, please see below.

Currently my previous changes introduce a terrible bug!